### PR TITLE
attempting a fix for SequelizeConnectionAcquireTimeoutError

### DIFF
--- a/app.js
+++ b/app.js
@@ -65,6 +65,16 @@ if (!fs.existsSync(logsDir)) {
     // Synchronize the models with the database (create tables if they don't exist)
     await sequelize.sync();
 
+    // Pre-warm the connection pool to minimum size
+    const minConnections = sequelize.options.pool.min || 2;
+    const warmupPromises = Array.from({ length: minConnections }, () =>
+      sequelize.query('SELECT 1 as warmup', {
+        type: sequelize.QueryTypes.SELECT
+      })
+    );
+    await Promise.all(warmupPromises);
+    logger.info(`Connection pool warmed up with ${minConnections} connections`);
+
     // Start connection monitoring
     connectionMonitor.start();
   } catch (error) {

--- a/app.js
+++ b/app.js
@@ -7,6 +7,7 @@ import session from 'express-session';
 import sequelize from './config/database.js';
 import ApiError from './utils/ApiError.js';
 import logger from './config/logger.js';
+import connectionMonitor from './utils/connectionMonitor.js';
 import fs from 'fs';
 import path from 'path';
 
@@ -40,7 +41,10 @@ import accountsManagementRoutes from './routes/admin/accountsManagement.routes.j
 import maintenanceManagementRoutes from './routes/admin/maintenanceManagement.routes.js';
 import bookingManagementRoutes from './routes/admin/bookingManagement.routes.js';
 // import utsavManagementRoutes from './routes/admin/utsavManagement.routes.js';
-import { utsavPublicRouter, utsavAdminRouter } from './routes/admin/utsavManagement.routes.js';
+import {
+  utsavPublicRouter,
+  utsavAdminRouter
+} from './routes/admin/utsavManagement.routes.js';
 import avtManagementRoutes from './routes/admin/avtManagement.routes.js';
 import wifiManagementRoutes from './routes/admin/wifiManagement.routes.js';
 
@@ -60,6 +64,9 @@ if (!fs.existsSync(logsDir)) {
 
     // Synchronize the models with the database (create tables if they don't exist)
     await sequelize.sync();
+
+    // Start connection monitoring
+    connectionMonitor.start();
   } catch (error) {
     logger.error('Unable to connect to the database:', error);
   }
@@ -95,6 +102,45 @@ app.get('/api', (_req, res) => {
   res.status(200).send({ data: 'API is up and running... 🚀', status: 200 });
 });
 
+// Health check endpoint with database connection test
+app.get('/api/health', async (_req, res) => {
+  try {
+    // Test database connection
+    await sequelize.authenticate();
+
+    // Get connection pool status
+    const pool = sequelize.connectionManager.pool;
+    const poolStatus = {
+      size: pool.size,
+      available: pool.available,
+      using: pool.using,
+      waiting: pool.waiting
+    };
+
+    // Get pool configuration for comparison
+    const poolConfig = sequelize.options.pool;
+
+    res.status(200).send({
+      status: 'healthy',
+      database: 'connected',
+      environment: process.env.NODE_ENV || 'dev',
+      pool: {
+        current: poolStatus,
+        configured: poolConfig
+      },
+      timestamp: new Date().toISOString()
+    });
+  } catch (error) {
+    logger.error('Health check failed:', error);
+    res.status(503).send({
+      status: 'unhealthy',
+      database: 'disconnected',
+      error: error.message,
+      timestamp: new Date().toISOString()
+    });
+  }
+});
+
 app.use('/api/v1/client', clientAuthRoutes);
 app.use('/api/v1/wifi', wifiRoutes);
 app.use('/api/v1/stay', roomRoutes);
@@ -122,7 +168,7 @@ app.use('/api/v1/admin/maintenance', maintenanceManagementRoutes);
 app.use('/api/v1/admin/bookings', bookingManagementRoutes);
 // app.use('/api/v1/admin/utsav', utsavManagementRoutes);
 app.use('/api/v1/admin/utsav', utsavPublicRouter); // No auth
-app.use('/api/v1/admin/utsav', utsavAdminRouter);  // With auth
+app.use('/api/v1/admin/utsav', utsavAdminRouter); // With auth
 app.use('/api/v1/admin/avt', avtManagementRoutes);
 app.use('/api/v1/admin/wifi', wifiManagementRoutes);
 
@@ -141,6 +187,50 @@ app.use(ErrorHandler);
 const port = process.env.PORT || 3000;
 const server = app.listen(port, () => {
   logger.info(`Server is listening on port ${port}...`);
+});
+
+// Graceful shutdown handling
+const gracefulShutdown = async (signal) => {
+  logger.info(`Received ${signal}. Starting graceful shutdown...`);
+
+  // Close HTTP server first
+  server.close(async () => {
+    logger.info('HTTP server closed');
+
+    try {
+      // Stop connection monitoring
+      connectionMonitor.stop();
+
+      // Close database connections
+      await sequelize.close();
+      logger.info('Database connections closed');
+      process.exit(0);
+    } catch (error) {
+      logger.error('Error during graceful shutdown:', error);
+      process.exit(1);
+    }
+  });
+
+  // Force shutdown after 30 seconds
+  setTimeout(() => {
+    logger.error('Forced shutdown after timeout');
+    process.exit(1);
+  }, 30000);
+};
+
+// Handle shutdown signals
+process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));
+process.on('SIGINT', () => gracefulShutdown('SIGINT'));
+
+// Handle uncaught exceptions
+process.on('uncaughtException', (error) => {
+  logger.error('Uncaught Exception:', error);
+  gracefulShutdown('uncaughtException');
+});
+
+process.on('unhandledRejection', (reason, promise) => {
+  logger.error('Unhandled Rejection at:', promise, 'reason:', reason);
+  gracefulShutdown('unhandledRejection');
 });
 
 // Export the app and a function to close the database connection

--- a/config/config.js
+++ b/config/config.js
@@ -11,7 +11,15 @@ const config = {
     database: process.env.DB_NAME,
     host: process.env.DB_HOST,
     port: process.env.DB_PORT,
-    dialect: 'mysql'
+    dialect: 'mysql',
+    pool: {
+      max: 5,
+      min: 2,
+      acquire: 60000, // Maximum time (ms) to try getting connection before throwing error
+      idle: 30000, // Maximum time (ms) a connection can be idle before being released
+      evict: 1000, // Time interval (ms) to run eviction to free idle connections
+      handleDisconnects: true // Automatically handle disconnects
+    }
   },
   qa: {
     username: process.env.DB_USERNAME,
@@ -26,7 +34,14 @@ const config = {
         ca: private_key
       }
     },
-    pool: { maxConnections: 5, maxIdleTime: 30 },
+    pool: {
+      max: 10,
+      min: 2,
+      acquire: 60000,
+      idle: 30000,
+      evict: 1000,
+      handleDisconnects: true
+    },
     language: 'en'
   },
   prod: {
@@ -35,7 +50,15 @@ const config = {
     database: process.env.DB_NAME,
     host: process.env.DB_HOST,
     port: process.env.DB_PORT,
-    dialect: 'mysql'
+    dialect: 'mysql',
+    pool: {
+      max: 25,
+      min: 5,
+      acquire: 60000,
+      idle: 30000,
+      evict: 1000,
+      handleDisconnects: true
+    }
   }
 };
 

--- a/config/config.js
+++ b/config/config.js
@@ -1,3 +1,5 @@
+// This file is used ONLY by Sequelize CLI for migrations and seeders
+// The actual application uses config/database.js for connection pooling
 import dotenv from 'dotenv';
 dotenv.config({ path: `.env.${process.env.NODE_ENV || 'dev'}` });
 
@@ -11,15 +13,7 @@ const config = {
     database: process.env.DB_NAME,
     host: process.env.DB_HOST,
     port: process.env.DB_PORT,
-    dialect: 'mysql',
-    pool: {
-      max: 5,
-      min: 2,
-      acquire: 60000, // Maximum time (ms) to try getting connection before throwing error
-      idle: 30000, // Maximum time (ms) a connection can be idle before being released
-      evict: 1000, // Time interval (ms) to run eviction to free idle connections
-      handleDisconnects: true // Automatically handle disconnects
-    }
+    dialect: 'mysql'
   },
   qa: {
     username: process.env.DB_USERNAME,
@@ -34,14 +28,7 @@ const config = {
         ca: private_key
       }
     },
-    pool: {
-      max: 10,
-      min: 2,
-      acquire: 60000,
-      idle: 30000,
-      evict: 1000,
-      handleDisconnects: true
-    },
+
     language: 'en'
   },
   prod: {
@@ -50,15 +37,7 @@ const config = {
     database: process.env.DB_NAME,
     host: process.env.DB_HOST,
     port: process.env.DB_PORT,
-    dialect: 'mysql',
-    pool: {
-      max: 25,
-      min: 5,
-      acquire: 60000,
-      idle: 30000,
-      evict: 1000,
-      handleDisconnects: true
-    }
+    dialect: 'mysql'
   }
 };
 

--- a/config/database.js
+++ b/config/database.js
@@ -1,3 +1,5 @@
+// This is the main database configuration used by the running application
+// Pool settings here control the actual connection behavior
 import { Sequelize } from 'sequelize';
 const { private_key } =
   process.env.NODE_ENV == 'qa' && JSON.parse(process.env.DB_CERT);
@@ -17,8 +19,8 @@ const sequelize = new Sequelize(
       }
     },
     pool: {
-      max: 10, // Maximum number of connections in pool
-      min: 2, // Minimum number of connections in pool
+      max: 25,
+      min: 2,
       acquire: 60000, // Maximum time (ms) to try getting connection before throwing error
       idle: 30000, // Maximum time (ms) a connection can be idle before being released
       evict: 1000, // Time interval (ms) to run eviction to free idle connections

--- a/config/database.js
+++ b/config/database.js
@@ -16,7 +16,14 @@ const sequelize = new Sequelize(
         ca: private_key
       }
     },
-    pool: { max: 5, idle: 30000 },
+    pool: {
+      max: 10, // Maximum number of connections in pool
+      min: 2, // Minimum number of connections in pool
+      acquire: 60000, // Maximum time (ms) to try getting connection before throwing error
+      idle: 30000, // Maximum time (ms) a connection can be idle before being released
+      evict: 1000, // Time interval (ms) to run eviction to free idle connections
+      handleDisconnects: true // Automatically handle disconnects
+    },
     language: 'en'
   }
 );

--- a/controllers/client/payment.controller.js
+++ b/controllers/client/payment.controller.js
@@ -155,6 +155,7 @@ export const createOrderIdForPendingPayments = async (req, res) => {
   const { bookingids } = req.body;
 
   const t = await database.transaction();
+  req.transaction = t;
 
   const transactions = await Transactions.findAll({
     where: {
@@ -199,6 +200,7 @@ export const createOrderIdForPendingPayments = async (req, res) => {
 export const createOrderIdForPendingPaymentsV2 = async (req, res) => {
   const { data } = req.body;
   const t = await database.transaction();
+  req.transaction = t;
 
   const bookingCategoryMap = data.reduce((map, { bookingid, category }) => {
     (map[bookingid] ??= []).push(category);

--- a/models/index.js
+++ b/models/index.js
@@ -1,29 +1,14 @@
 'use strict';
 
+import { fileURLToPath } from 'url';
 import fs from 'fs';
 import path from 'path';
 import Sequelize from 'sequelize';
-import process from 'process';
-import { fileURLToPath } from 'url';
+import sequelize from '../config/database.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const basename = path.basename(__filename);
-const env = process.env.NODE_ENV || 'development';
-import configFile from '../config/config.js';
-const config = configFile[env];
 const db = {};
-
-let sequelize;
-if (config.use_env_variable) {
-  sequelize = new Sequelize(process.env[config.use_env_variable], config);
-} else {
-  sequelize = new Sequelize(
-    config.database,
-    config.username,
-    config.password,
-    config
-  );
-}
 
 fs.readdirSync(path.dirname(__filename))
   .filter(

--- a/utils/connectionMonitor.js
+++ b/utils/connectionMonitor.js
@@ -1,0 +1,90 @@
+import logger from '../config/logger.js';
+import sequelize from '../config/database.js';
+
+/**
+ * Monitor database connection pool status
+ */
+export class ConnectionMonitor {
+  constructor(intervalMs = 60000) { // Default: check every minute
+    this.intervalMs = intervalMs;
+    this.monitoringInterval = null;
+    this.isMonitoring = false;
+  }
+
+  start() {
+    if (this.isMonitoring) {
+      logger.warn('Connection monitor is already running');
+      return;
+    }
+
+    this.isMonitoring = true;
+    logger.info('Starting connection pool monitoring');
+
+    this.monitoringInterval = setInterval(() => {
+      this.checkConnectionPool();
+    }, this.intervalMs);
+
+    // Initial check
+    this.checkConnectionPool();
+  }
+
+  stop() {
+    if (this.monitoringInterval) {
+      clearInterval(this.monitoringInterval);
+      this.monitoringInterval = null;
+    }
+    this.isMonitoring = false;
+    logger.info('Connection pool monitoring stopped');
+  }
+
+  checkConnectionPool() {
+    try {
+      const pool = sequelize.connectionManager.pool;
+      
+      const status = {
+        size: pool.size,
+        available: pool.available,
+        using: pool.using,
+        waiting: pool.waiting,
+        timestamp: new Date().toISOString()
+      };
+
+      // Log warnings for potential issues
+      if (status.waiting > 0) {
+        logger.warn(`Connection pool has ${status.waiting} waiting connections`, status);
+      }
+
+      if (status.using / status.size > 0.8) {
+        logger.warn(`Connection pool usage is high: ${status.using}/${status.size}`, status);
+      }
+
+      if (status.available === 0 && status.using === status.size) {
+        logger.error('Connection pool exhausted!', status);
+      }
+
+      // Log info every 10 minutes (600 seconds)
+      if (Date.now() % 600000 < this.intervalMs) {
+        logger.info('Connection pool status:', status);
+      }
+
+    } catch (error) {
+      logger.error('Failed to check connection pool status:', error);
+    }
+  }
+
+  async testConnection() {
+    try {
+      await sequelize.authenticate();
+      logger.info('Database connection test successful');
+      return true;
+    } catch (error) {
+      logger.error('Database connection test failed:', error);
+      return false;
+    }
+  }
+}
+
+// Create singleton instance
+const connectionMonitor = new ConnectionMonitor();
+
+export default connectionMonitor;

--- a/utils/connectionMonitor.js
+++ b/utils/connectionMonitor.js
@@ -5,7 +5,8 @@ import sequelize from '../config/database.js';
  * Monitor database connection pool status
  */
 export class ConnectionMonitor {
-  constructor(intervalMs = 60000) { // Default: check every minute
+  constructor(intervalMs = 60000) {
+    // Default: check every minute
     this.intervalMs = intervalMs;
     this.monitoringInterval = null;
     this.isMonitoring = false;
@@ -40,7 +41,7 @@ export class ConnectionMonitor {
   checkConnectionPool() {
     try {
       const pool = sequelize.connectionManager.pool;
-      
+
       const status = {
         size: pool.size,
         available: pool.available,
@@ -51,24 +52,31 @@ export class ConnectionMonitor {
 
       // Log warnings for potential issues
       if (status.waiting > 0) {
-        logger.warn(`Connection pool has ${status.waiting} waiting connections`, status);
+        logger.warn(
+          `Connection pool has ${
+            status.waiting
+          } waiting connections - ${JSON.stringify(status)}`
+        );
       }
 
       if (status.using / status.size > 0.8) {
-        logger.warn(`Connection pool usage is high: ${status.using}/${status.size}`, status);
+        logger.warn(
+          `Connection pool usage is high: ${status.using}/${
+            status.size
+          } - ${JSON.stringify(status)}`
+        );
       }
 
       if (status.available === 0 && status.using === status.size) {
-        logger.error('Connection pool exhausted!', status);
+        logger.error(`Connection pool exhausted! - ${JSON.stringify(status)}`);
       }
 
       // Log info every 10 minutes (600 seconds)
       if (Date.now() % 600000 < this.intervalMs) {
-        logger.info('Connection pool status:', status);
+        logger.info(`Connection pool status: ${JSON.stringify(status)}`);
       }
-
     } catch (error) {
-      logger.error('Failed to check connection pool status:', error);
+      logger.error(`Failed to check connection pool status: ${error.message}`);
     }
   }
 
@@ -78,7 +86,7 @@ export class ConnectionMonitor {
       logger.info('Database connection test successful');
       return true;
     } catch (error) {
-      logger.error('Database connection test failed:', error);
+      logger.error(`Database connection test failed: ${error.message}`);
       return false;
     }
   }

--- a/utils/queryTimeout.js
+++ b/utils/queryTimeout.js
@@ -1,0 +1,66 @@
+import database from '../config/database.js';
+import logger from '../config/logger.js';
+
+/**
+ * Execute a query with timeout to prevent connection hanging
+ * @param {string} query - SQL query string
+ * @param {Object} options - Query options including replacements, type, etc.
+ * @param {number} timeoutMs - Timeout in milliseconds (default: 30000)
+ * @returns {Promise} Query result
+ */
+export const queryWithTimeout = async (query, options = {}, timeoutMs = 30000) => {
+  const queryPromise = database.query(query, options);
+  
+  const timeoutPromise = new Promise((_, reject) => {
+    setTimeout(() => {
+      reject(new Error(`Query timeout after ${timeoutMs}ms: ${query.substring(0, 100)}...`));
+    }, timeoutMs);
+  });
+
+  try {
+    const result = await Promise.race([queryPromise, timeoutPromise]);
+    return result;
+  } catch (error) {
+    logger.error(`Query failed or timed out: ${error.message}`);
+    throw error;
+  }
+};
+
+/**
+ * Execute a transaction with timeout
+ * @param {Function} transactionFn - Function that receives transaction object
+ * @param {number} timeoutMs - Timeout in milliseconds (default: 60000)
+ * @returns {Promise} Transaction result
+ */
+export const transactionWithTimeout = async (transactionFn, timeoutMs = 60000) => {
+  let transaction;
+  
+  try {
+    transaction = await database.transaction();
+    
+    const transactionPromise = transactionFn(transaction);
+    
+    const timeoutPromise = new Promise((_, reject) => {
+      setTimeout(() => {
+        reject(new Error(`Transaction timeout after ${timeoutMs}ms`));
+      }, timeoutMs);
+    });
+
+    const result = await Promise.race([transactionPromise, timeoutPromise]);
+    await transaction.commit();
+    return result;
+    
+  } catch (error) {
+    if (transaction) {
+      try {
+        await transaction.rollback();
+        logger.warn('Transaction rolled back due to error or timeout');
+      } catch (rollbackError) {
+        logger.error(`Failed to rollback transaction: ${rollbackError.message}`);
+      }
+    }
+    throw error;
+  }
+};
+
+export default { queryWithTimeout, transactionWithTimeout };


### PR DESCRIPTION
- fixed pool configuration
- fixed transaction assignment
- added connection monitoring
- implemented graceful shutdown
- fixed dual sequelize instance issue
- timeput protection prevents connection timeouts
- ` config/database.js` (Main database connection for your app)
- ` config/config.js ` (Database credentials for CLI tools)

> The most critical fix is the `acquire: 60000` timeout setting, which will prevent the `SequelizeConnectionAcquireTimeoutError` by ensuring connections are acquired within 60 seconds or the operation fails gracefully rather than hanging indefinitely.