### PR TITLE
fix: correct utsav pagination offset and include utsavs without packages

### DIFF
--- a/controllers/client/utsavBooking.controller.js
+++ b/controllers/client/utsavBooking.controller.js
@@ -4,8 +4,7 @@ import {
 } from '../../config/constants.js';
 import {
   UtsavBooking,
-  UtsavDb,
-  UtsavPackagesDb
+  UtsavDb
 } from '../../models/associations.js';
 import { userCancelBooking } from '../../helpers/transactions.helper.js';
 import { openUtsavSeat, sendUtsavBookingUpdateEmail } from '../../helpers/utsavBooking.helper.js';
@@ -23,7 +22,7 @@ export const FetchUpcoming = async (req, res) => {
 
   const page = parseInt(req.query.page) || 1;
   const pageSize = parseInt(req.query.page_size) || 10;
-  const offset = (page - 1) * (pageSize - 1);
+  const offset = (page - 1) * pageSize;
 
   const utsavs = await database.query(
     `
@@ -35,7 +34,7 @@ export const FetchUpcoming = async (req, res) => {
        t1.location AS utsav_location,
        t1.status AS utsav_status,
        t1.registration_deadline AS registration_deadline,
-       JSON_ARRAYAGG(
+       IF(COUNT(t2.id) = 0, JSON_ARRAY(), JSON_ARRAYAGG(
            JSON_OBJECT(
                'package_id', t2.id,
                'package_name', t2.name,
@@ -43,9 +42,9 @@ export const FetchUpcoming = async (req, res) => {
                'package_end', t2.end_date,
                'package_amount', t2.amount
            )
-       ) AS packages
+       )) AS packages
     FROM utsav_db t1
-    JOIN utsav_packages_db t2 ON t1.id = t2.utsavid
+    LEFT JOIN utsav_packages_db t2 ON t1.id = t2.utsavid
     WHERE t1.registration_deadline IS NULL OR t1.registration_deadline >= :today
     GROUP BY t1.id
     ORDER BY t1.start_date ASC


### PR DESCRIPTION
- Fix offset calculation: (page-1)*(pageSize-1) → (page-1)*pageSize Previous formula caused page 2 to overlap with page 1 by 1 item, creating infinite pagination loop that crashed React Query for users with 9+ upcoming utsavs (REACT-NATIVE-KK)
- Change JOIN → LEFT JOIN on utsav_packages_db so utsavs with no packages are still returned, with packages as empty JSON array