### PR TITLE
fix: respect wallet credit on travel amount edits and utsav orders

### DIFF
--- a/controllers/admin/travelManagement.controller.js
+++ b/controllers/admin/travelManagement.controller.js
@@ -27,7 +27,8 @@ import {
 import {
   adminCancelTransaction,
   createPendingTransaction,
-  cancelTransaction
+  cancelTransaction,
+  adjustAmount
 } from '../../helpers/transactions.helper.js';
 import { sendDualUserNotifications } from '../../helpers/notification.helper.js';
 import { updateWaitingTravelBooking, sendTravelBookingStatusUpdateMail } from '../../helpers/travelBooking.helper.js';
@@ -852,13 +853,12 @@ export async function updateBooking(req, res) {
       throw new ApiError(404, 'Transaction not found');
     }
 
-    await transaction.update(
-      {
-        amount,
-        updatedBy: req.user.username,
-      },
-      { transaction: t }
-    );
+    const parsedAmount = Number(amount);
+    if (!Number.isFinite(parsedAmount) || parsedAmount < 0) {
+      throw new ApiError(400, 'Amount must be a non-negative number');
+    }
+
+    await adjustAmount(transaction, parsedAmount, req.user.username, t);
 
     updatedFields.push('amount');
   }

--- a/helpers/transactions.helper.js
+++ b/helpers/transactions.helper.js
@@ -245,36 +245,55 @@ export async function cancelTransaction(
   return { credits };
 }
 
-export async function adjustAmount(
-  card,
-  booking,
-  transaction,
-  amount,
-  updatedBy,
-  t
-) {
-  const originalAmount = transaction.amount + transaction.discount;
-  const bookingType = getBookingType(transaction);
-
-  if (originalAmount > amount) {
-    const credits = originalAmount - amount;
-    await addCredit(user, card, bookingType, credits, t);
-    await useCredit(card, booking, transaction, amount, updatedBy, t);
-  } else if (originalAmount < amount) {
-    const balance = amount - originalAmount;
-    await transaction.update(
-      {
-        // set status to cash pending as only admin
-        // can call this function
-        status: STATUS_CASH_PENDING,
-        discount: originalAmount,
-        amount: balance,
-        description: `Transaction updated. New Balance ${balance}.`,
-        updatedBy: updatedBy
-      },
-      { transaction: t }
-    );
+/**
+ * Adjusts the net amount owed on a pending transaction (admin edit).
+ *
+ * `amount` is the new NET the customer owes — a non-negative number that the
+ * caller is responsible for parsing/validating. It matches the value the admin
+ * travel report displays and re-submits (`transactions.amount`, already
+ * post-credit). Credits already applied (`transaction.discount`) are left
+ * untouched; this never adds or refunds wallet credit. Re-submitting the
+ * unchanged value is a no-op, which is what stops redundant admin saves from
+ * corrupting the transaction.
+ *
+ * Scope: updates the transaction row only (amount + settled status). Booking
+ * status is intentionally left to the booking-status endpoints.
+ */
+export async function adjustAmount(transaction, amount, updatedBy, t) {
+  if (
+    [STATUS_PAYMENT_COMPLETED, STATUS_CASH_COMPLETED].includes(
+      transaction.status
+    )
+  ) {
+    throw new ApiError(400, 'Cannot update amount for a completed transaction');
   }
+
+  // Idempotent: an unchanged net (the common redundant-save case) is a no-op.
+  if (Number(transaction.amount) === amount) return;
+
+  const discount = Number(transaction.discount);
+
+  // Nothing left to collect — settle the transaction, preserving cash vs online.
+  let status = transaction.status;
+  if (amount === 0) {
+    status =
+      transaction.status === STATUS_CASH_PENDING
+        ? STATUS_CASH_COMPLETED
+        : STATUS_PAYMENT_COMPLETED;
+  }
+
+  await transaction.update(
+    {
+      amount,
+      status,
+      description:
+        discount > 0
+          ? `Balance updated to ${amount} (credits used: ${discount})`
+          : `Balance updated to ${amount}`,
+      updatedBy
+    },
+    { transaction: t }
+  );
 }
 
 function getCreditType(bookingType) {

--- a/helpers/utsavBooking.helper.js
+++ b/helpers/utsavBooking.helper.js
@@ -89,13 +89,14 @@ export async function bookUtsavForMumukshus(utsavid, mumukshus, t, user) {
       { transaction: t }
     );
     
-    // 🟢 UPDATED CONDITIONAL
     if (
       utsav.status === STATUS_OPEN &&
       status === STATUS_PAYMENT_PENDING &&
       package_info.amount > 0
     ) {
-      await createPendingTransaction(
+      // Accumulate the post-credit (discounted) amount into the order total,
+      // matching the room/adhyayan helpers — not the gross package_info.amount.
+      const { discountedAmount } = await createPendingTransaction(
         user,
         booking,
         TYPE_UTSAV,
@@ -103,10 +104,8 @@ export async function bookUtsavForMumukshus(utsavid, mumukshus, t, user) {
         user.cardno,
         t
       );
-      
-      total_amount += package_info.amount;
-      
-      
+
+      total_amount += discountedAmount;
     }
     await bookFoodForUtsav(package_info , utsav, mumukshu, t, user.cardno);
     bookings.push(bookingid);

--- a/tests/unit/transactions.helper.test.js
+++ b/tests/unit/transactions.helper.test.js
@@ -1,0 +1,72 @@
+import { adjustAmount } from '../../helpers/transactions.helper.js';
+import {
+  STATUS_PAYMENT_PENDING,
+  STATUS_CASH_PENDING,
+  STATUS_PAYMENT_COMPLETED,
+  STATUS_CASH_COMPLETED
+} from '../../config/constants.js';
+
+// adjustAmount only calls transaction.update(), so a plain mock object exercises
+// the full logic without touching the DB.
+function makeTxn({ amount, discount, status }) {
+  const txn = { amount, discount, status };
+  txn.update = jest.fn(async (payload) => Object.assign(txn, payload));
+  return txn;
+}
+
+describe('adjustAmount — net-based admin amount edit', () => {
+  it('is a no-op when the net is unchanged (the redundant-save bug)', async () => {
+    const txn = makeTxn({ amount: 130, discount: 400, status: STATUS_PAYMENT_PENDING });
+    await adjustAmount(txn, 130, 'admin', null);
+    expect(txn.update).not.toHaveBeenCalled();
+  });
+
+  it('lowers the net without refunding already-applied credit', async () => {
+    const txn = makeTxn({ amount: 130, discount: 400, status: STATUS_PAYMENT_PENDING });
+    await adjustAmount(txn, 50, 'admin', null);
+    const payload = txn.update.mock.calls[0][0];
+    expect(payload.amount).toBe(50);
+    expect(payload.status).toBe(STATUS_PAYMENT_PENDING);
+    expect(payload).not.toHaveProperty('discount'); // wallet untouched
+    expect(payload.description).toMatch(/credits used: 400/);
+  });
+
+  it('raises the net while keeping the pending status', async () => {
+    const txn = makeTxn({ amount: 130, discount: 400, status: STATUS_PAYMENT_PENDING });
+    await adjustAmount(txn, 200, 'admin', null);
+    expect(txn.update.mock.calls[0][0]).toMatchObject({
+      amount: 200,
+      status: STATUS_PAYMENT_PENDING
+    });
+  });
+
+  it('settles an online transaction when the net hits 0', async () => {
+    const txn = makeTxn({ amount: 130, discount: 400, status: STATUS_PAYMENT_PENDING });
+    await adjustAmount(txn, 0, 'admin', null);
+    expect(txn.update.mock.calls[0][0]).toMatchObject({
+      amount: 0,
+      status: STATUS_PAYMENT_COMPLETED
+    });
+  });
+
+  it('settles a cash transaction as cash-completed when the net hits 0', async () => {
+    const txn = makeTxn({ amount: 130, discount: 400, status: STATUS_CASH_PENDING });
+    await adjustAmount(txn, 0, 'admin', null);
+    expect(txn.update.mock.calls[0][0].status).toBe(STATUS_CASH_COMPLETED);
+  });
+
+  it('uses a plain description when no credit is applied', async () => {
+    const txn = makeTxn({ amount: 399, discount: 0, status: STATUS_PAYMENT_PENDING });
+    await adjustAmount(txn, 400, 'admin', null);
+    expect(txn.update.mock.calls[0][0].description).toBe('Balance updated to 400');
+  });
+
+  it.each([STATUS_PAYMENT_COMPLETED, STATUS_CASH_COMPLETED])(
+    'rejects editing a completed transaction (%s) and never mutates it',
+    async (status) => {
+      const txn = makeTxn({ amount: 0, discount: 530, status });
+      await expect(adjustAmount(txn, 100, 'admin', null)).rejects.toThrow(/completed/i);
+      expect(txn.update).not.toHaveBeenCalled();
+    }
+  );
+});


### PR DESCRIPTION
## Fix: wallet credit not respected on travel amount edits & utsav orders

### Problem

Customers were overcharged when wallet credits were involved, via two independent bugs:

**Bug A — Utsav booking (`utsavBooking.helper.js`)**
`bookUtsavForMumukshus` added the gross `package_info.amount` to the Razorpay order total instead of the post-credit `discountedAmount` returned by `createPendingTransaction`. A customer with ₹400 credit on a ₹530 package had the wallet correctly debited (`amount=130, discount=400`) but an order created for the full ₹530.

**Bug B — Travel booking update (`travelManagement.controller.js`)**
`PUT /admin/travel/bookingupdate` blindly overwrote `transaction.amount` with the submitted value. The admin travel report displays and re-submits `transactions.amount` (the **net**, already post-credit), so redundant/identical admin saves corrupted the amount/discount split and could regenerate the Razorpay order for the wrong total.

### Fix

**`helpers/transactions.helper.js` — `adjustAmount` (net-based rewrite)**
- Treats the submitted `amount` as the **net owed** — matching what the admin report shows and re-submits.
- **Idempotent**: an unchanged net is a no-op. This is what stops redundant admin saves from corrupting the transaction.
- Credits already applied (`transaction.discount`) are left untouched — never adds or refunds wallet credit.
- Settles the transaction when the net reaches 0 (cash → cash-completed, online → payment-completed).
- Rejects edits to already-completed transactions.
- (The previous `adjustAmount` referenced an undefined `user` and had gross/credit logic that didn't match the frontend; it was unused, so no live impact.)

**`controllers/admin/travelManagement.controller.js` — `updateBooking`**
- Validates `amount` (finite, non-negative) and routes it through `adjustAmount` instead of overwriting `transaction.amount` directly.

**`helpers/utsavBooking.helper.js` — `bookUtsavForMumukshus`**
- Accumulates the post-credit `discountedAmount` into the order total, matching the room/adhyayan helpers.

**Tests** — `tests/unit/transactions.helper.test.js` covers `adjustAmount`: idempotent no-op, raise/lower net, settle-to-zero (cash vs online), and the completed-transaction guard.

### Behaviour after fix

| Scenario | Before | After |
|----------|--------|-------|
| Admin re-saves unchanged amount (redundant call) | ❌ corrupts amount/discount | ✅ no-op |
| Admin lowers the net owed | ❌ | ✅ net updated, credit untouched |
| Admin raises the net owed | ❌ | ✅ net updated, stays pending |
| Admin sets net to 0 | ❌ | ✅ transaction settled (cash/online preserved) |
| Edit on a completed transaction | ❌ silently mutated | ✅ rejected (400) |
| Utsav booking with wallet credit | ❌ order for gross | ✅ order for net |

### Notes

- Net-based semantics match the existing admin frontend (`aashray-admin/admin/travel/fetchUpcomingBookings.js`), which sends `transactions.amount`. **No frontend change required.**
- Rebuilt on current `dev` — the earlier branch was based on a stale merge base and conflicted with dev's bus-coordinator / `leaving_post_adhyayan` work. This version merges cleanly and carries no unrelated reformatting.
