### PR TITLE
Fix: Send email on every utsav status update

### DIFF
--- a/controllers/admin/utsavManagement.controller.js
+++ b/controllers/admin/utsavManagement.controller.js
@@ -816,6 +816,8 @@ export const utsavStatusUpdate = async (req, res) => {
 
         await t.commit();
 
+        await sendUtsavBookingUpdateEmail(booking, utsav);
+
         return res.status(200).send({
           message:
             'Since package amount is 0, updating the status to confirmed.'
@@ -940,6 +942,9 @@ export const utsavStatusUpdate = async (req, res) => {
   );
 
   await t.commit();
+
+  await sendUtsavBookingUpdateEmail(booking, utsav);
+
   req.log.info('utsav_status_update_transition', { bookingid, utsav_id, fromStatus: booking.status, toStatus: newBookingStatus });
   return res.status(200).send({ message: 'Updated booking status' });
 };

--- a/emails/utsavStatusUpdate.hbs
+++ b/emails/utsavStatusUpdate.hbs
@@ -26,8 +26,8 @@
                 <p><b>pending:</b> This means you need to complete your payment within 24 hours to secure your adhyayan booking on the Vitraag Vigyaan Aashray mobile app.</p>
                 <p><b>waiting:</b> All Utsav spots are currently booked. You've been placed on the waiting list and will be notified if a spot becomes available.</p>
                 <p><b>confirmed:</b> Great news! Your Utsav booking has been successfully confirmed.</p>
-                <p><b>cancelled:</b> Your adhyayan booking has been self cancelled.</p>
-                <p><b>admin cancelled:</b> Your adhyayan booking has been cancelled by the administrator.</p>
+                <p><b>cancelled:</b> Your Utsav booking has been self cancelled.</p>
+                <p><b>admin cancelled:</b> Your Utsav booking has been cancelled by the administrator.</p>
             </div>
             <p>If you have any further questions or need assistance, please feel free to contact us at <b>+91-7875432613 / +91-9004273512</b>.</p>
         </div>


### PR DESCRIPTION
## Summary
- Call `sendUtsavBookingUpdateEmail` after every status transition in `utsavStatusUpdate`
- Covers the zero-amount auto-confirm early return path as well
- Email is sent after `t.commit()` so it only fires if the DB update succeeded

## Test plan
- [ ] Update a utsav booking status to `confirmed` — verify email is sent
- [ ] Update a utsav booking status to `payment_pending` — verify email is sent
- [ ] Update a utsav booking status to `admin_cancelled` — verify email is sent
- [ ] Book a zero-amount utsav package — verify auto-confirm email is sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)