### PR TITLE
fix: make utsav-feedback migrations idempotent (unblock prod deploy)

### DIFF
--- a/migrations/20260201035615-add-utsav-feedback-model.js
+++ b/migrations/20260201035615-add-utsav-feedback-model.js
@@ -1,5 +1,17 @@
 'use strict';
 
+// Returns true if an index/constraint with the given name already exists on the
+// table. Used to keep this migration idempotent: the schema may already be in
+// place (e.g. applied out of band) while SequelizeMeta has no record of it.
+async function indexExists(queryInterface, tableName, indexName) {
+  const [rows] = await queryInterface.sequelize.query(
+    `SELECT COUNT(*) AS count FROM information_schema.STATISTICS
+     WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = :tableName AND INDEX_NAME = :indexName`,
+    { replacements: { tableName, indexName } }
+  );
+  return Number(rows[0].count) > 0;
+}
+
 module.exports = {
   async up(queryInterface, Sequelize) {
     await queryInterface.createTable('utsav_feedback', {
@@ -112,14 +124,31 @@ module.exports = {
       }
     });
 
-    await queryInterface.addConstraint('utsav_feedback', {
-      fields: ['utsav_id', 'cardno'],
-      type: 'unique',
-      name: 'unique_feedback_per_user_per_utsav'
-    });
+    if (
+      !(await indexExists(
+        queryInterface,
+        'utsav_feedback',
+        'unique_feedback_per_user_per_utsav'
+      ))
+    ) {
+      await queryInterface.addConstraint('utsav_feedback', {
+        fields: ['utsav_id', 'cardno'],
+        type: 'unique',
+        name: 'unique_feedback_per_user_per_utsav'
+      });
+    }
 
-    await queryInterface.addIndex('utsav_feedback', ['utsav_id']);
-    await queryInterface.addIndex('utsav_feedback', ['cardno']);
+    if (
+      !(await indexExists(queryInterface, 'utsav_feedback', 'utsav_feedback_utsav_id'))
+    ) {
+      await queryInterface.addIndex('utsav_feedback', ['utsav_id']);
+    }
+
+    if (
+      !(await indexExists(queryInterface, 'utsav_feedback', 'utsav_feedback_cardno'))
+    ) {
+      await queryInterface.addIndex('utsav_feedback', ['cardno']);
+    }
   },
 
   async down(queryInterface) {

--- a/migrations/20260522044619-create-utsav-feedback-answers.js
+++ b/migrations/20260522044619-create-utsav-feedback-answers.js
@@ -1,5 +1,17 @@
 'use strict';
 
+// Returns true if an index with the given name already exists on the table.
+// Keeps this migration idempotent when the schema is already present but
+// unrecorded in SequelizeMeta.
+async function indexExists(queryInterface, tableName, indexName) {
+  const [rows] = await queryInterface.sequelize.query(
+    `SELECT COUNT(*) AS count FROM information_schema.STATISTICS
+     WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = :tableName AND INDEX_NAME = :indexName`,
+    { replacements: { tableName, indexName } }
+  );
+  return Number(rows[0].count) > 0;
+}
+
 module.exports = {
   async up(queryInterface, Sequelize) {
     await queryInterface.createTable('utsav_feedback_answers', {
@@ -54,15 +66,25 @@ module.exports = {
       }
     });
 
-    await queryInterface.addIndex(
-      'utsav_feedback_answers',
-      ['feedback_id']
-    );
+    if (
+      !(await indexExists(
+        queryInterface,
+        'utsav_feedback_answers',
+        'utsav_feedback_answers_feedback_id'
+      ))
+    ) {
+      await queryInterface.addIndex('utsav_feedback_answers', ['feedback_id']);
+    }
 
-    await queryInterface.addIndex(
-      'utsav_feedback_answers',
-      ['question_id']
-    );
+    if (
+      !(await indexExists(
+        queryInterface,
+        'utsav_feedback_answers',
+        'utsav_feedback_answers_question_id'
+      ))
+    ) {
+      await queryInterface.addIndex('utsav_feedback_answers', ['question_id']);
+    }
   },
 
   async down(queryInterface) {

--- a/migrations/20260522044916-update-utsav-feedback-structure.js
+++ b/migrations/20260522044916-update-utsav-feedback-structure.js
@@ -1,99 +1,56 @@
 'use strict';
 
+// Returns true if the column already exists on the table. Keeps this migration
+// idempotent when the schema change was already applied but not recorded in
+// SequelizeMeta.
+async function columnExists(queryInterface, tableName, columnName) {
+  const [rows] = await queryInterface.sequelize.query(
+    `SELECT COUNT(*) AS count FROM information_schema.COLUMNS
+     WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = :tableName AND COLUMN_NAME = :columnName`,
+    { replacements: { tableName, columnName } }
+  );
+  return Number(rows[0].count) > 0;
+}
+
+const COLUMNS = [
+  'accommodation_rating',
+  'qr_rating',
+  'food_rating',
+  'program_rating',
+  'volunteer_rating',
+  'infrastructure_rating',
+  'decor_rating',
+  'internal_transport_rating',
+  'raj_pravas_rating',
+  'sparsh_rating',
+  'av_rating',
+  'loved_most',
+  'improvement_suggestions'
+];
+
 module.exports = {
   async up(queryInterface) {
-    await queryInterface.removeColumn('utsav_feedback', 'accommodation_rating');
-    await queryInterface.removeColumn('utsav_feedback', 'qr_rating');
-    await queryInterface.removeColumn('utsav_feedback', 'food_rating');
-    await queryInterface.removeColumn('utsav_feedback', 'program_rating');
-    await queryInterface.removeColumn('utsav_feedback', 'volunteer_rating');
-    await queryInterface.removeColumn('utsav_feedback', 'infrastructure_rating');
-    await queryInterface.removeColumn('utsav_feedback', 'decor_rating');
-    await queryInterface.removeColumn('utsav_feedback', 'internal_transport_rating');
-    await queryInterface.removeColumn('utsav_feedback', 'raj_pravas_rating');
-    await queryInterface.removeColumn('utsav_feedback', 'sparsh_rating');
-    await queryInterface.removeColumn('utsav_feedback', 'av_rating');
-    await queryInterface.removeColumn('utsav_feedback', 'loved_most');
-    await queryInterface.removeColumn('utsav_feedback', 'improvement_suggestions');
+    for (const column of COLUMNS) {
+      if (await columnExists(queryInterface, 'utsav_feedback', column)) {
+        await queryInterface.removeColumn('utsav_feedback', column);
+      }
+    }
   },
 
   async down(queryInterface, Sequelize) {
-    await queryInterface.addColumn('utsav_feedback', 'accommodation_rating', {
-      type: Sequelize.INTEGER,
-      allowNull: false,
-      defaultValue: 1
-    });
+    const textColumns = ['loved_most', 'improvement_suggestions'];
 
-    await queryInterface.addColumn('utsav_feedback', 'qr_rating', {
-      type: Sequelize.INTEGER,
-      allowNull: false,
-      defaultValue: 1
-    });
+    for (const column of COLUMNS) {
+      if (await columnExists(queryInterface, 'utsav_feedback', column)) {
+        continue;
+      }
 
-    await queryInterface.addColumn('utsav_feedback', 'food_rating', {
-      type: Sequelize.INTEGER,
-      allowNull: false,
-      defaultValue: 1
-    });
-
-    await queryInterface.addColumn('utsav_feedback', 'program_rating', {
-      type: Sequelize.INTEGER,
-      allowNull: false,
-      defaultValue: 1
-    });
-
-    await queryInterface.addColumn('utsav_feedback', 'volunteer_rating', {
-      type: Sequelize.INTEGER,
-      allowNull: false,
-      defaultValue: 1
-    });
-
-    await queryInterface.addColumn('utsav_feedback', 'infrastructure_rating', {
-      type: Sequelize.INTEGER,
-      allowNull: false,
-      defaultValue: 1
-    });
-
-    await queryInterface.addColumn('utsav_feedback', 'decor_rating', {
-      type: Sequelize.INTEGER,
-      allowNull: false,
-      defaultValue: 1
-    });
-
-    await queryInterface.addColumn('utsav_feedback', 'internal_transport_rating', {
-      type: Sequelize.INTEGER,
-      allowNull: false,
-      defaultValue: 1
-    });
-
-    await queryInterface.addColumn('utsav_feedback', 'raj_pravas_rating', {
-      type: Sequelize.INTEGER,
-      allowNull: false,
-      defaultValue: 1
-    });
-
-    await queryInterface.addColumn('utsav_feedback', 'sparsh_rating', {
-      type: Sequelize.INTEGER,
-      allowNull: false,
-      defaultValue: 1
-    });
-
-    await queryInterface.addColumn('utsav_feedback', 'av_rating', {
-      type: Sequelize.INTEGER,
-      allowNull: false,
-      defaultValue: 1
-    });
-
-    await queryInterface.addColumn('utsav_feedback', 'loved_most', {
-      type: Sequelize.TEXT,
-      allowNull: false,
-      defaultValue: ''
-    });
-
-    await queryInterface.addColumn('utsav_feedback', 'improvement_suggestions', {
-      type: Sequelize.TEXT,
-      allowNull: false,
-      defaultValue: ''
-    });
+      const isText = textColumns.includes(column);
+      await queryInterface.addColumn('utsav_feedback', column, {
+        type: isText ? Sequelize.TEXT : Sequelize.INTEGER,
+        allowNull: false,
+        defaultValue: isText ? '' : 1
+      });
+    }
   }
 };


### PR DESCRIPTION
## Problem

The **Node.js CI/CD** deploy workflow on `main` fails at the `db:migrate` step (run `28691356313`, PR #333 merge):

```
== 20260201035615-add-utsav-feedback-model: migrating =======
ERROR: Duplicate key name 'unique_feedback_per_user_per_utsav'
  at Object.up (migrations/20260201035615-add-utsav-feedback-model.js:115:5)
```

The Render web service itself is live/healthy — this is purely the migration/deploy pipeline.

## Root cause

All three utsav-feedback migrations are **already applied to the DB schema** but **none are recorded in `SequelizeMeta`**:

| Migration | Schema in DB | In SequelizeMeta |
|---|---|---|
| `20260201…add-utsav-feedback-model` | table + unique constraint + 2 indexes present | ❌ |
| `20260522044619…create-utsav-feedback-answers` | table present | ❌ |
| `20260522044916…update-utsav-feedback-structure` | old rating columns already dropped | ❌ |

Sequelize's `createTable` emits `CREATE TABLE IF NOT EXISTS` on MySQL, so the table step silently no-ops and the following `addConstraint` throws `Duplicate key name`. Since the migration never records, **every deploy retries it and fails**.

## Fix

Make the three migrations idempotent:
- Guard `addConstraint` / `addIndex` by checking `information_schema.STATISTICS` for the index name.
- Guard `removeColumn` by checking `information_schema.COLUMNS`.

On the next deploy the migrations find everything already in place, do nothing, and get recorded in `SequelizeMeta` — unblocking the pipeline. Fresh environments (dev/test) still create everything normally.

## Notes
- No manual prod DB write needed; the fix self-heals on the next `db:migrate`.
- `dev` still carries the non-idempotent versions; once these are recorded in `SequelizeMeta` they won't re-run, so there's no regression, but consider syncing `dev` to avoid confusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)