### PR TITLE
Fix: block multiple Utsav package bookings (+ tidy cancellation fix)

### DIFF
--- a/controllers/client/payment.controller.js
+++ b/controllers/client/payment.controller.js
@@ -112,7 +112,7 @@ export const verifyPayment = async (req, res) => {
           // for late-checkout-fee, while a transaction is created,
           // a corresponding booking is not created.
           if (booking) {
-            if (booking.status === STATUS_CANCELLED || booking.status === STATUS_ADMIN_CANCELLED) {
+            if ([STATUS_CANCELLED, STATUS_ADMIN_CANCELLED].includes(booking.status)) {
               req.log.warn('payment_received_for_cancelled_booking', {
                 bookingid: booking.bookingid,
                 cardno: booking.cardno,

--- a/helpers/transactions.helper.js
+++ b/helpers/transactions.helper.js
@@ -161,13 +161,18 @@ export async function cancelTransaction(
     );
   }
 
+  const bookingType = getBookingType(transaction);
+
   if (
     !admin &&
-    [TYPE_TRAVEL, TYPE_UTSAV].includes(getBookingType(transaction)) &&
+    [TYPE_TRAVEL, TYPE_UTSAV].includes(bookingType) &&
     [STATUS_PAYMENT_COMPLETED, STATUS_CASH_COMPLETED].includes(transaction.status)
   ) {
-    // User cancelling via app — no credits, keep transaction as completed
-    logger.info('cancel_transaction_user_no_credits', { transactionId: transaction.id, bookingType: getBookingType(transaction) });
+    // User cancelling a paid travel/utsav booking via the app:
+    // no credits are issued and the transaction stays 'completed'.
+    // Pending/failed transactions deliberately fall through so they still
+    // get marked cancelled below (otherwise they'd be left dangling).
+    logger.info('cancel_transaction_user_no_credits', { transactionId: transaction.id, bookingType });
     return { credits: 0 }; // no credits added
   }
 
@@ -180,8 +185,6 @@ export async function cancelTransaction(
       transaction.status == STATUS_CASH_COMPLETED
       ? totalAmount
       : transaction.discount;
-
-  const bookingType = getBookingType(transaction);
 
   switch (transaction.status) {
     case STATUS_PAYMENT_COMPLETED:

--- a/helpers/utsavBooking.helper.js
+++ b/helpers/utsavBooking.helper.js
@@ -13,6 +13,7 @@ import {
   ERR_UTSAV_NOT_FOUND,
   FEEDBACK_ELIGIBILITY_HOUR,
   ERR_UTSAV_FEEDBACK_NOT_ALLOWED,
+  STATUS_CASH_PENDING,
   STATUS_CASH_COMPLETED,
   ERR_UTSAV_FEEDBACK_ALREADY_SUBMITTED,
   ROOM_STATUS_CHECKEDIN
@@ -43,6 +44,21 @@ import sendMail from '../utils/sendMail.js';
 import { bookFoodForAllMeals, cancelAllMeals } from './foodBooking.helper.js';
 const SAMVATSARI_PACKAGE_ID = 21;
 const SAMVATSARI_OVERLAPPING_PACKAGE_IDS = [18, 20];
+
+// Utsav booking statuses that represent an existing (non-cancelled) booking.
+// A member holding a booking in any of these is "already booked" for that Utsav
+// and may not book it (or an overlapping package) again. Only 'cancelled' /
+// 'admin cancelled' bookings are ignored. Previously this list omitted
+// checkedin / cash pending / cash completed, which let a member whose first
+// booking had advanced past confirmed book a second package for the same Utsav.
+const ACTIVE_UTSAV_BOOKING_STATUSES = [
+  STATUS_PAYMENT_PENDING,
+  STATUS_CONFIRMED,
+  STATUS_WAITING,
+  STATUS_CASH_PENDING,
+  STATUS_CASH_COMPLETED,
+  ROOM_STATUS_CHECKEDIN
+];
 
 export async function bookUtsavForMumukshus(utsavid, mumukshus, t, user) {
   const utsav = await UtsavDb.findOne({ where: { id: utsavid } });
@@ -223,11 +239,7 @@ export async function checkUtsavAlreadyBooked(utsavid, mumukshus) {
       cardno: mumukshu_cardnos,
       utsavid: utsavid,
       status: {
-        [Sequelize.Op.in]: [
-          STATUS_PAYMENT_PENDING,
-          STATUS_CONFIRMED,
-          STATUS_WAITING
-        ]
+        [Sequelize.Op.in]: ACTIVE_UTSAV_BOOKING_STATUSES
       }
     }
   });
@@ -263,7 +275,7 @@ export async function checkOverlapWithSamvatsari(mumukshus) {
     {
       replacements: {
         cardnos: mumukshu_cardnos,
-        status: [STATUS_PAYMENT_PENDING, STATUS_CONFIRMED, STATUS_WAITING],
+        status: ACTIVE_UTSAV_BOOKING_STATUSES,
         samvatsari_package_id: SAMVATSARI_PACKAGE_ID,
         samvatsari_overlapping_packages: SAMVATSARI_OVERLAPPING_PACKAGE_IDS,
         packages_overlap_with_samvatsari: mumukshu_packages.some((packageid) =>


### PR DESCRIPTION
## Summary

Two related Utsav fixes, split into two commits.

### 1. `fix`: block booking multiple packages for the same Utsav
Members could book **more than one package for the same Utsav**. The
`checkUtsavAlreadyBooked` guard (and the Samvatsari-overlap guard) only
treated `pending` / `confirmed` / `waiting` bookings as "already booked" —
it ignored `checkedin`, `cash pending`, and `cash completed`. So once a
member's first booking advanced past confirmed, the guard no longer saw it
and a second package went through.

**Confirmed in production:** one member had package 18 (`checkedin`) plus
package 20 (`waiting`) for the same Utsav; the second was booked two weeks
after check-in.

**Fix:** consolidated the blocking statuses into a single
`ACTIVE_UTSAV_BOOKING_STATUSES` list and used it in both guards. Only
`cancelled` / `admin cancelled` are ignored, so re-booking after a
cancellation still works. Both the member (app/guest) and admin booking
paths run through this guard.

### 2. `refactor`: tidy up the utsav/travel cancellation fix
Cleanup of the code from the cancellation fix already merged to `dev`
(no behavior change):
- compute `bookingType` once in `cancelTransaction` instead of 3×
- document why pending/failed transactions deliberately fall through to be cancelled
- use array `.includes` for the already-cancelled guard in `verifyPayment` (matches codebase idiom)

## Testing
The Utsav booking test suite is currently unimplemented `test.todo` stubs and
the suite is DB-backed, so no automated test was run. The duplicate-booking
fix was verified against production data and by tracing the guard logic. Happy
to add an integration test for the guard if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
