### PR TITLE
Fix: block same-request duplicate Utsav booking (primary + addon)

### DIFF
--- a/controllers/client/guestBooking.controller.js
+++ b/controllers/client/guestBooking.controller.js
@@ -57,7 +57,8 @@ import {
 } from '../../helpers/foodBooking.helper.js';
 import {
   validateUtsavs,
-  bookUtsavForMumukshus
+  bookUtsavForMumukshus,
+  validateNoDuplicateUtsavBooking
 } from '../../helpers/utsavBooking.helper.js';
 import {
   bookAdhyayanForMumukshus,
@@ -308,6 +309,12 @@ export const guestBooking = async (req, res) => {
 export const validateBooking = async (req, res) => {
   attachUserContext(req);
   const { primary_booking, addons } = req.body;
+
+  // A member can hold only one booking per utsav — reject if the same utsav is
+  // selected more than once for the same person across primary + addons, so the
+  // user is blocked here before proceeding to payment.
+  validateNoDuplicateUtsavBooking(primary_booking, addons);
+
   req.log.info('validate_guest_booking_start', {
     cardno: req.user.cardno,
     primaryBookingType: primary_booking?.booking_type,

--- a/controllers/client/mumukshuBooking.controller.js
+++ b/controllers/client/mumukshuBooking.controller.js
@@ -38,7 +38,8 @@ import {
 } from '../../helpers/foodBooking.helper.js';
 import {
   bookUtsavForMumukshus,
-  validateUtsavs
+  validateUtsavs,
+  validateNoDuplicateUtsavBooking
 } from '../../helpers/utsavBooking.helper.js';
 import { validateCards } from '../../helpers/card.helper.js';
 import {
@@ -167,6 +168,12 @@ async function fetchFreshDetailsForCard(cardno, userBookingIdMap) {
 export const validateBooking = async (req, res) => {
   attachUserContext(req);
   const { primary_booking, addons } = req.body;
+
+  // A member can hold only one booking per utsav — reject if the same utsav is
+  // selected more than once for the same person across primary + addons, so the
+  // user is blocked here before proceeding to payment.
+  validateNoDuplicateUtsavBooking(primary_booking, addons);
+
   req.log.info('validate_mumukshu_booking_start', {
     cardno: req.user.cardno,
     primaryBookingType: primary_booking?.booking_type,

--- a/helpers/utsavBooking.helper.js
+++ b/helpers/utsavBooking.helper.js
@@ -65,7 +65,7 @@ export async function bookUtsavForMumukshus(utsavid, mumukshus, t, user) {
   if (!utsav) throw new ApiError(400, 'Utsav not found');
 
   const packages = await UtsavPackagesDb.findAll({ where: { utsavid } });
-  await checkUtsavAlreadyBooked(utsavid, mumukshus);
+  await checkUtsavAlreadyBooked(utsavid, mumukshus, t);
 
   let total_amount = 0;
   let available_seats = utsav.available_seats;
@@ -183,7 +183,7 @@ export async function bookUtsavForMumukshusAdmin(
 
   const packages = await UtsavPackagesDb.findAll({ where: { utsavid } });
 
-  await checkUtsavAlreadyBooked(utsavid, mumukshus);
+  await checkUtsavAlreadyBooked(utsavid, mumukshus, t);
 
   let total_amount = 0;
   let userBookingIds = {},
@@ -232,8 +232,40 @@ export async function bookUtsavForMumukshusAdmin(
   return { amount: total_amount, userBookingIds, waitingBookingCount };
 }
 
-export async function checkUtsavAlreadyBooked(utsavid, mumukshus) {
+// Request-level guard: a member may hold only one booking per utsav, so the
+// same utsav must not be selected more than once for the same person across
+// the primary booking and its addons. Runs synchronously at validation time
+// (before the user proceeds to payment). Works for both the mumukshu
+// (`details.mumukshus`) and guest (`details.guests`) booking shapes.
+export function validateNoDuplicateUtsavBooking(primary_booking, addons) {
+  const utsavEntries = [primary_booking, ...(addons || [])].filter(
+    (entry) => entry && entry.booking_type === TYPE_UTSAV
+  );
+
+  const seen = new Set();
+  for (const entry of utsavEntries) {
+    const utsavid = entry.details?.utsavid;
+    const people = entry.details?.mumukshus ?? entry.details?.guests ?? [];
+    for (const person of people) {
+      const key = `${utsavid}:${person.cardno}`;
+      if (seen.has(key)) throw new ApiError(400, ERR_UTSAV_ALREADY_BOOKED);
+      seen.add(key);
+    }
+  }
+}
+
+export async function checkUtsavAlreadyBooked(utsavid, mumukshus, t = null) {
   const mumukshu_cardnos = mumukshus.map((mumukshu) => mumukshu.cardno);
+
+  // Reject the same card appearing more than once for this utsav in a single
+  // request (e.g. the same person as primary booking + addon) — otherwise each
+  // entry passes the DB check below and creates its own booking.
+  if (new Set(mumukshu_cardnos).size !== mumukshu_cardnos.length)
+    throw new ApiError(400, ERR_UTSAV_ALREADY_BOOKED);
+
+  // Read within the caller's transaction so a booking created earlier in the
+  // same request (e.g. the primary utsav booking) is visible when checking a
+  // later one (its addon), instead of only seeing committed rows.
   const alreadyBooked = await UtsavBooking.findAll({
     where: {
       cardno: mumukshu_cardnos,
@@ -241,16 +273,17 @@ export async function checkUtsavAlreadyBooked(utsavid, mumukshus) {
       status: {
         [Sequelize.Op.in]: ACTIVE_UTSAV_BOOKING_STATUSES
       }
-    }
+    },
+    transaction: t
   });
 
   if (alreadyBooked.length > 0)
     throw new ApiError(400, ERR_UTSAV_ALREADY_BOOKED);
 
-  await checkOverlapWithSamvatsari(mumukshus);
+  await checkOverlapWithSamvatsari(mumukshus, t);
 }
 
-export async function checkOverlapWithSamvatsari(mumukshus) {
+export async function checkOverlapWithSamvatsari(mumukshus, t = null) {
   const mumukshu_cardnos = mumukshus.map((mumukshu) => mumukshu.cardno);
   const mumukshu_packages = mumukshus.map((mumukshu) => mumukshu.packageid);
 
@@ -285,7 +318,8 @@ export async function checkOverlapWithSamvatsari(mumukshus) {
           SAMVATSARI_PACKAGE_ID
         )
       },
-      type: Sequelize.QueryTypes.SELECT
+      type: Sequelize.QueryTypes.SELECT,
+      transaction: t
     }
   );
 


### PR DESCRIPTION
## Summary
Closes the remaining way a member could book **two packages for the same Utsav**:
selecting the same Utsav as both the **primary booking and an addon** in a single
request (this is how Sagar Zaveri got Package A + Package B for Guru Purnima 2026).

The existing guard only looked up **pre-existing** DB rows, so at check time nothing
existed and both bookings were created. The earlier status-list fix (already merged
via #338) didn't cover this, because there was no prior booking to find.

## Changes
- **`validateNoDuplicateUtsavBooking`** — new request-level check, run in **both**
  client `validateBooking` endpoints, so the user is blocked **before proceeding to
  payment** when the same Utsav is selected more than once for the same person across
  the primary booking + addons.
- **`checkUtsavAlreadyBooked`** — also rejects the same card appearing twice within a
  single batch, and now reads **within the caller's transaction**, so a booking
  created earlier in the same request (the primary) is visible when checking a later
  one (the addon). Closes the write-time hole too.
- **`checkOverlapWithSamvatsari`** — same transaction-awareness.

## Testing
Verified the dedup logic against Sagar's exact scenario + 5 other cases (his case
blocked; legitimate cases — different people same Utsav, same person different Utsavs,
Utsav-with-room — all allowed). Suite is DB-backed with `test.todo` Utsav stubs, so no
automated test was run.

## Known remaining edge
Two genuinely simultaneous **separate** requests (a rapid double-submit race) could
still slip past, since the transaction-aware check only helps within one request. The
belt-and-braces fix is a DB uniqueness rule on (card, Utsav) for non-cancelled bookings
— awkward in MySQL (needs a generated-column trick); flagged as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
