### PR TITLE
fix(payment): idempotent Razorpay order creation to prevent orphaned payments

### DIFF
--- a/controllers/client/payment.controller.js
+++ b/controllers/client/payment.controller.js
@@ -18,10 +18,7 @@ import {
 } from '../../config/constants.js';
 import { Transactions, RazorpayWebhook } from '../../models/associations.js';
 import { sendUnifiedEmail } from '../helper.js';
-import {
-  generateOrderId,
-  updateRazorpayTransactions
-} from '../../helpers/transactions.helper.js';
+import { resolveOrderForTransactions } from '../../helpers/transactions.helper.js';
 import { getBooking, getBookingType } from '../../helpers/booking.helper.js';
 import { validateCard } from '../../helpers/card.helper.js';
 import { attachUserContext } from '../../middleware/Logger.js';
@@ -84,7 +81,7 @@ export const verifyPayment = async (req, res) => {
         STATUS_PAYMENT_AUTHORIZED
       ]
     },
-    lock: { update: true },
+    lock: true,
     transaction: t
   });
 
@@ -288,7 +285,9 @@ export const createOrderIdForPendingPayments = async (req, res) => {
         STATUS_CASH_PENDING,
         STATUS_PAYMENT_FAILED
       ]
-    }
+    },
+    lock: true,
+    transaction: t
   });
 
   const hasDisallowedCategory = transactions.some((transaction) => {
@@ -312,9 +311,14 @@ export const createOrderIdForPendingPayments = async (req, res) => {
   req.log.info('create_order_total_amount', { cardno: req.user.cardno, totalAmount, transactionCount: transactions.length });
 
   if (totalAmount > 0) {
-    const order = await generateOrderId(totalAmount);
+    const order = await resolveOrderForTransactions(
+      transactions,
+      totalAmount,
+      bookingids,
+      [],
+      t
+    );
     req.log.info('create_order_generated', { cardno: req.user.cardno, orderId: order.id, amount: totalAmount });
-    await updateRazorpayTransactions(bookingids, [], order.id, t);
     await t.commit();
     req.log.info('create_order_success', { cardno: req.user.cardno, orderId: order.id });
 
@@ -350,7 +354,9 @@ export const createOrderIdForPendingPaymentsV2 = async (req, res) => {
         STATUS_CASH_PENDING,
         STATUS_PAYMENT_FAILED
       ]
-    }
+    },
+    lock: true,
+    transaction: t
   });
 
   req.log.info('create_order_v2_transactions_found', {
@@ -358,7 +364,7 @@ export const createOrderIdForPendingPaymentsV2 = async (req, res) => {
     transactionCount: transactions.length
   });
 
-  const { totalAmount, validTransactionIds } = transactions.reduce(
+  const { totalAmount, validTransactions } = transactions.reduce(
     (acc, transaction) => {
       const categories = bookingCategoryMap[transaction.bookingid];
       const bookingType = getBookingType(transaction);
@@ -367,12 +373,14 @@ export const createOrderIdForPendingPaymentsV2 = async (req, res) => {
         categories.includes(transaction.category)
       ) {
         acc.totalAmount += transaction.amount;
-        acc.validTransactionIds.push(transaction.id);
+        acc.validTransactions.push(transaction);
       }
       return acc;
     },
-    { totalAmount: 0, validTransactionIds: [] }
+    { totalAmount: 0, validTransactions: [] }
   );
+
+  const validTransactionIds = validTransactions.map((txn) => txn.id);
 
   req.log.info('create_order_v2_total_amount', {
     cardno: req.user.cardno,
@@ -381,10 +389,14 @@ export const createOrderIdForPendingPaymentsV2 = async (req, res) => {
   });
 
   if (totalAmount > 0) {
-    const order = await generateOrderId(totalAmount);
+    const order = await resolveOrderForTransactions(
+      validTransactions,
+      totalAmount,
+      [],
+      validTransactionIds,
+      t
+    );
     req.log.info('create_order_v2_generated', { cardno: req.user.cardno, orderId: order.id, amount: totalAmount });
-
-    await updateRazorpayTransactions([], validTransactionIds, order.id, t);
     await t.commit();
     req.log.info('create_order_v2_success', { cardno: req.user.cardno, orderId: order.id });
 

--- a/helpers/transactions.helper.js
+++ b/helpers/transactions.helper.js
@@ -411,11 +411,18 @@ function getUpdatedCredits(card, creditType, newCredits) {
   return updatedCredits;
 }
 
-export const generateOrderId = async (amount) => {
-  const razorpay = new Razorpay({
+const getRazorpayClient = () =>
+  new Razorpay({
     key_id: process.env.RAZORPAY_KEY_ID,
     key_secret: process.env.RAZORPAY_KEY_SECRET
   });
+
+// Envs where Razorpay orders are real (created/fetched via the API). Elsewhere
+// order ids are local uuid stubs and must not be sent to Razorpay.
+const isRazorpayLiveEnv = () => ['prod', 'qa'].includes(process.env.NODE_ENV);
+
+export const generateOrderId = async (amount) => {
+  const razorpay = getRazorpayClient();
 
   const options = {
     amount: amount * 100,
@@ -428,7 +435,7 @@ export const generateOrderId = async (amount) => {
   };
 
   var order;
-  if (['prod', 'qa'].includes(process.env.NODE_ENV) && amount > 0) {
+  if (isRazorpayLiveEnv() && amount > 0) {
     order = await razorpay.orders.create(options);
   } else {
     options['id'] = uuidv4();
@@ -493,3 +500,105 @@ export async function updateRazorpayTransactions(
     }
   );
 }
+
+// Razorpay order statuses that are still payable, so the order can be reused.
+const REUSABLE_RAZORPAY_ORDER_STATUSES = ['created', 'attempted'];
+
+/**
+ * Returns the Razorpay order id shared by every transaction, or null.
+ * Only returns an id when ALL transactions carry the same non-null
+ * razorpay_order_id. A mixed or partial set (some blank, or differing ids)
+ * means a fresh order is safer.
+ */
+export const getSharedRazorpayOrderId = (transactions) => {
+  if (!transactions || transactions.length === 0) return null;
+  const orderIds = new Set(transactions.map((txn) => txn.razorpay_order_id));
+  const [orderId] = [...orderIds];
+  return orderIds.size === 1 && orderId ? orderId : null;
+};
+
+/**
+ * Inspects an existing Razorpay order to decide whether it can be reused.
+ * Returns:
+ *   { order } -> reuse this order (still payable and amount matches)
+ *   { paid }  -> order already paid; caller must NOT create a new one
+ *   null      -> not reusable; a fresh order should be created
+ * In non prod/qa envs the stored id is a local uuid (no real Razorpay order),
+ * so a payable stub is reconstructed instead of calling Razorpay.
+ */
+export const inspectRazorpayOrder = async (razorpay_order_id, amount) => {
+  const expectedAmount = Math.round(amount * 100);
+  const payableStub = {
+    order: { id: razorpay_order_id, amount: expectedAmount, currency: 'INR' }
+  };
+
+  // Non prod/qa: stored id is a local uuid, no real Razorpay order to fetch.
+  if (!isRazorpayLiveEnv()) {
+    return payableStub;
+  }
+
+  try {
+    const order = await getRazorpayClient().orders.fetch(razorpay_order_id);
+    if (!order) return null;
+    if (order.status === 'paid') return { paid: true };
+    if (
+      REUSABLE_RAZORPAY_ORDER_STATUSES.includes(order.status) &&
+      order.amount === expectedAmount
+    ) {
+      return { order };
+    }
+    return null;
+  } catch (err) {
+    // Fail closed: on a transient fetch error, reuse the existing order id
+    // instead of minting a new one, which would overwrite and orphan an
+    // in-flight payment. Razorpay rejects re-paying a paid/expired order,
+    // so this cannot double-charge.
+    logger.warn('razorpay_order_fetch_failed_reusing_existing', {
+      razorpay_order_id,
+      error: err?.message
+    });
+    return payableStub;
+  }
+};
+
+/**
+ * Idempotently resolves the Razorpay order for a set of pending transactions.
+ *
+ * If the transactions already share a reusable (still payable, same-amount)
+ * order it is returned as-is, so retrying "Pay" never overwrites the stored
+ * razorpay_order_id and never orphans an in-flight payment. A new order is
+ * created and persisted only when there is no reusable one.
+ *
+ * @throws ApiError(409) when the existing order was already paid — that needs
+ *   reconciliation, not another payable order (avoids double-charging).
+ */
+export const resolveOrderForTransactions = async (
+  transactions,
+  amount,
+  bookingIds,
+  transactionIds,
+  t
+) => {
+  const existingOrderId = getSharedRazorpayOrderId(transactions);
+
+  if (existingOrderId) {
+    const existing = await inspectRazorpayOrder(existingOrderId, amount);
+    if (existing?.paid) {
+      throw new ApiError(
+        409,
+        'Payment already received for this booking. Please contact support if it is not yet confirmed.'
+      );
+    }
+    if (existing?.order) {
+      logger.info('reuse_existing_razorpay_order', {
+        razorpay_order_id: existingOrderId,
+        amount
+      });
+      return existing.order;
+    }
+  }
+
+  const order = await generateOrderId(amount);
+  await updateRazorpayTransactions(bookingIds, transactionIds, order.id, t);
+  return order;
+};

--- a/helpers/transactions.helper.js
+++ b/helpers/transactions.helper.js
@@ -421,6 +421,26 @@ const getRazorpayClient = () =>
 // order ids are local uuid stubs and must not be sent to Razorpay.
 const isRazorpayLiveEnv = () => ['prod', 'qa'].includes(process.env.NODE_ENV);
 
+// Order creation/lookup runs while a FOR UPDATE lock is held on the pending
+// transactions, so a hung Razorpay call would pin a DB connection and block
+// concurrent confirmations. Bound every Razorpay HTTP call so a slow/hung
+// response fails fast and releases the lock instead of holding it indefinitely.
+const RAZORPAY_REQUEST_TIMEOUT_MS = 15000;
+
+const withRazorpayTimeout = async (promise, label) => {
+  let timer;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise((_, reject) => {
+        timer = setTimeout(() => reject(new Error(label)), RAZORPAY_REQUEST_TIMEOUT_MS);
+      })
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
 export const generateOrderId = async (amount) => {
   const razorpay = getRazorpayClient();
 
@@ -436,7 +456,10 @@ export const generateOrderId = async (amount) => {
 
   var order;
   if (isRazorpayLiveEnv() && amount > 0) {
-    order = await razorpay.orders.create(options);
+    order = await withRazorpayTimeout(
+      razorpay.orders.create(options),
+      'razorpay_order_create_timeout'
+    );
   } else {
     options['id'] = uuidv4();
     order = options;
@@ -538,7 +561,10 @@ export const inspectRazorpayOrder = async (razorpay_order_id, amount) => {
   }
 
   try {
-    const order = await getRazorpayClient().orders.fetch(razorpay_order_id);
+    const order = await withRazorpayTimeout(
+      getRazorpayClient().orders.fetch(razorpay_order_id),
+      'razorpay_order_fetch_timeout'
+    );
     if (!order) return null;
     if (order.status === 'paid') return { paid: true };
     if (
@@ -549,13 +575,26 @@ export const inspectRazorpayOrder = async (razorpay_order_id, amount) => {
     }
     return null;
   } catch (err) {
-    // Fail closed: on a transient fetch error, reuse the existing order id
-    // instead of minting a new one, which would overwrite and orphan an
-    // in-flight payment. Razorpay rejects re-paying a paid/expired order,
-    // so this cannot double-charge.
+    // A definitive 4xx (order not found / bad request / auth) means the stored
+    // id is permanently broken — reusing it would leave the customer unable to
+    // ever pay. Fall through to creating a fresh order instead.
+    const statusCode = Number(err?.statusCode ?? err?.error?.statusCode);
+    if (statusCode >= 400 && statusCode < 500) {
+      logger.error('razorpay_order_fetch_invalid_order', {
+        razorpay_order_id,
+        statusCode,
+        error: err?.message ?? err?.error?.description
+      });
+      return null;
+    }
+
+    // Transient (network / 5xx / timeout): fail closed by reusing the existing
+    // order id instead of minting a new one, which would overwrite and orphan
+    // an in-flight payment. Razorpay rejects re-paying a paid/expired order, so
+    // this cannot double-charge.
     logger.warn('razorpay_order_fetch_failed_reusing_existing', {
       razorpay_order_id,
-      error: err?.message
+      error: err?.message ?? err?.error?.description
     });
     return payableStub;
   }


### PR DESCRIPTION
## Problem

Retrying **Pay** on a pending booking created a brand-new Razorpay order every time and unconditionally overwrote `transactions.razorpay_order_id`.

Real incident: a member tapped Pay, went back, tapped Pay again (new order id, old one overwritten), then completed payment on the **first** checkout screen. Razorpay captured the money under the **first** order, but its webhook could no longer find a matching transaction (the stored id had already moved to the second order). The booking was never confirmed and was later cancelled for "non-payment in time" — despite the money being captured. Result: an orphaned payment needing manual refund.

Root cause: the order id is a single, overwritable field, and order creation was not idempotent.

## Fix (create-side idempotency)

- **`resolveOrderForTransactions`** reuses an existing shared, still-payable order instead of minting a new one, so the stored order id is **never overwritten on retry**. A new order is created only when there is genuinely no reusable one.
- **409 on already-paid**: if the existing order was already paid, reject rather than create another payable order — needs reconciliation, not a second charge.
- **Fail closed on Razorpay outage**: `inspectRazorpayOrder` reuses the existing id on a transient `orders.fetch` error rather than fabricating a new order (which would re-introduce the orphaning). Razorpay rejects re-paying a paid/expired order, so this can't double-charge.
- **Serialize double-taps**: row lock (`FOR UPDATE`) on the pending transactions during order creation, so near-simultaneous taps can't both create orders.

## Also
- Extracted `getRazorpayClient` / `isRazorpayLiveEnv` helpers.
- Upgraded the fragile `lock: { update: true }` form to the documented `lock: true` (also in the webhook handler).

## Scope / follow-ups (intentionally not in this PR)
- **Webhook resilience**: match payments against prior/overwritten order ids (closes the residual orphan risk when the cart amount legitimately changes between taps).
- **Other order-creation callers** (guest/mumukshu/room) not yet made idempotent — lower risk since they're fresh-booking flows.
- **Reconciliation** of already-orphaned captured payments (query `razorpay_webhook` for order ids matching no transaction).
- App/admin clients may need to handle the new **409** response.

## Testing notes
Pure Node syntax-checked (`node --check`) on both files. Backend Jest can't run in this sandbox (offline module import). Non-prod/qa uses local uuid order stubs, so the reuse path is exercisable in dev; the paid-409 and amount-mismatch branches only trigger against real Razorpay orders in prod/qa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)