### PR TITLE
fix(reports): eliminate N+1 in room/flat reservation reports

### DIFF
--- a/controllers/admin/roomManagement.controller.js
+++ b/controllers/admin/roomManagement.controller.js
@@ -1290,10 +1290,14 @@ export const ReservationReport = async (req, res) => {
   req.log.info('reservation_report_start', { start_date, end_date, statuses });
 
   // Pagination is optional: the admin report UI fetches the full result set,
-  // so we only paginate when the caller explicitly provides page_size.
+  // so we only paginate when the caller explicitly provides a valid page_size.
   const page = parseInt(req.query.page) || req.body.page || 1;
   const rawPageSize = req.query.page_size || req.body.page_size;
-  const pageSize = rawPageSize ? parseInt(rawPageSize) : null;
+  let pageSize = rawPageSize ? parseInt(rawPageSize) : null;
+  if (pageSize !== null && (Number.isNaN(pageSize) || pageSize <= 0)) {
+    req.log.warn('reservation_report_invalid_page_size', { page_size: rawPageSize });
+    pageSize = null;
+  }
 
   const reservations = await roomBookingReport(
     start_date,
@@ -1331,7 +1335,7 @@ export const flatReservationReport = async (req, res) => {
     whereClause.status = { [Sequelize.Op.in]: statusArray };
   }
 
-  const bookings = await FlatBooking.findAll({
+  let bookings = await FlatBooking.findAll({
     include: [
       {
         model: CardDb,
@@ -1351,7 +1355,7 @@ export const flatReservationReport = async (req, res) => {
     order: [['checkin', 'ASC']]
   });
 
-  await attachLatestTransactions(bookings);
+  bookings = await attachLatestTransactions(bookings);
 
   req.log.info('flat_reservation_report_success', { start_date, end_date, count: bookings.length });
   return res
@@ -1464,7 +1468,7 @@ async function attachLatestTransactions(bookings) {
 
   const txns = await Transactions.findAll({
     attributes: ['bookingid', 'status', 'description'],
-    where: { bookingid: { [Sequelize.Op.in]: bookingIds } },
+    where: { bookingid: { [Op.in]: bookingIds } },
     order: [['createdAt', 'DESC']]
   });
 

--- a/controllers/admin/roomManagement.controller.js
+++ b/controllers/admin/roomManagement.controller.js
@@ -1289,8 +1289,11 @@ export const ReservationReport = async (req, res) => {
   const { start_date, end_date, statuses } = req.query;
   req.log.info('reservation_report_start', { start_date, end_date, statuses });
 
+  // Pagination is optional: the admin report UI fetches the full result set,
+  // so we only paginate when the caller explicitly provides page_size.
   const page = parseInt(req.query.page) || req.body.page || 1;
-  const pageSize = parseInt(req.query.page_size) || req.body.page_size || 1000;
+  const rawPageSize = req.query.page_size || req.body.page_size;
+  const pageSize = rawPageSize ? parseInt(rawPageSize) : null;
 
   const reservations = await roomBookingReport(
     start_date,
@@ -1334,15 +1337,6 @@ export const flatReservationReport = async (req, res) => {
         model: CardDb,
         attributes: ['cardno', 'issuedto', 'mobno', 'center'],
         required: true
-      },
-      {
-        model: Transactions,
-        as: 'transactions',
-        attributes: ['status', 'description'],
-        required: false,
-        separate: true,
-        limit: 1,
-        order: [['createdAt', 'DESC']]
       }
     ],
     attributes: [
@@ -1356,6 +1350,8 @@ export const flatReservationReport = async (req, res) => {
     where: whereClause,
     order: [['checkin', 'ASC']]
   });
+
+  await attachLatestTransactions(bookings);
 
   req.log.info('flat_reservation_report_success', { start_date, end_date, count: bookings.length });
   return res
@@ -1419,21 +1415,12 @@ export const dayWiseGuestCountReport = async (req, res) => {
 };
 
 async function roomBookingReport(startDate, endDate, page, pageSize, statuses) {
-  const data = await RoomBooking.findAll({
+  const queryOptions = {
     include: [
       {
         model: CardDb,
         attributes: ['cardno', 'issuedto', 'mobno', 'center', 'credits'],
         required: true
-      },
-      {
-        model: Transactions,
-        as: 'transactions',
-        attributes: ['status', 'description'],
-        required: false,
-        separate: true,
-        limit: 1,
-        order: [['createdAt', 'DESC']]
       }
     ],
     attributes: [
@@ -1454,9 +1441,50 @@ async function roomBookingReport(startDate, endDate, page, pageSize, statuses) {
       ]
     },
     order: [['checkin', 'ASC']]
+  };
+
+  // Only apply limit/offset when the caller explicitly requested pagination.
+  if (pageSize) {
+    queryOptions.limit = pageSize;
+    queryOptions.offset = ((page || 1) - 1) * pageSize;
+  }
+
+  const bookings = await RoomBooking.findAll(queryOptions);
+  return attachLatestTransactions(bookings);
+}
+
+// Attach each booking's most recent transaction as a single-element
+// `transactions` array (or []), matching the shape the admin report UI reads
+// (`booking.transactions[0]`). Uses one batched query instead of Sequelize's
+// per-row `separate: true` + `limit: 1` include, which fires one query per
+// booking — the N+1 that exhausted the DB connection pool on large reports.
+async function attachLatestTransactions(bookings) {
+  const bookingIds = bookings.map((b) => b.bookingid);
+  if (bookingIds.length === 0) return bookings;
+
+  const txns = await Transactions.findAll({
+    attributes: ['bookingid', 'status', 'description'],
+    where: { bookingid: { [Sequelize.Op.in]: bookingIds } },
+    order: [['createdAt', 'DESC']]
   });
-  console.log(JSON.stringify(data[0], null, 2));
-  return data;
+
+  // Rows are newest-first, so the first row seen per booking is its latest.
+  const latestByBooking = new Map();
+  for (const txn of txns) {
+    if (!latestByBooking.has(txn.bookingid)) {
+      latestByBooking.set(txn.bookingid, {
+        status: txn.status,
+        description: txn.description
+      });
+    }
+  }
+
+  for (const booking of bookings) {
+    const latest = latestByBooking.get(booking.bookingid);
+    booking.setDataValue('transactions', latest ? [latest] : []);
+  }
+
+  return bookings;
 }
 
 export const updateBookingStatus = async (req, res) => {


### PR DESCRIPTION
## Why

The room and flat reservation reports each loaded their transactions with a Sequelize `separate: true` + `limit: 1` include. That combination makes Sequelize fire **one query per booking** to get each booking's latest transaction.

On **2026-07-08** an admin ran the room reservation report over a ~13-month range (~7,100 bookings, ~95% of all bookings). That issued thousands of per-booking transaction queries, each sorting the transactions table, which:
- exhausted the DB connection pool (`Connection pool exhausted! using:4`),
- filled the MySQL temp dir on the near-full root volume (`errno 28 - No space left on device`),
- and cascaded into `connect ETIMEDOUT` across **every** endpoint (app + admin) for ~1 hour until a restart.

## What changed

- **Extract a shared `attachLatestTransactions()` helper** — fetches the latest transaction per booking in a **single batched `IN(...)` query** and attaches it in the exact same shape the admin UI reads (`booking.transactions[0].{status,description}`, or `[]`). ~7,000 queries → 2.
- **Apply it to both `roomBookingReport` and `flatReservationReport`** — the flat report had the identical N+1, so it's fixed here too (not left as a landmine).
- **Make `reservation_report` pagination optional-but-functional** — `page`/`page_size` were read then ignored (dead params). Now `limit`/`offset` apply only when `page_size` is explicitly passed, preserving the "return all rows" default the report/export UI needs. No behavior change for the current UI.
- **Remove** a stray `console.log(JSON.stringify(...))` debug statement.

## Behavior / compatibility

- Response shape is unchanged; the sole consumer (`aashray-admin/admin/room/roomReports.js`) reads `booking.transactions?.[0]?.status`, which is preserved (including `[]` for bookings with no transactions).
- Latest-transaction selection validated against the live DB: ordering by `createdAt DESC` and taking the first row per booking matches `MAX(createdAt)`.

## Verification

- `node --check` passes; no remaining `separate: true` include in the file.
- Batched-latest logic validated against production data (read-only).
- **Not** load-tested against prod end-to-end on purpose — the DB host disk was still ~96% full at time of writing. Full end-to-end verification should run on staging after the separate infra fix (free root disk + point MySQL `tmpdir` to the `/db` volume).

## Notes / follow-ups (out of scope)

- Infra: MySQL `tmpdir` sits on the full root volume; big query temp files spill there. Moving it to the empty `/db` volume + adding disk headroom is the complementary infra fix.
- There is no hard upper bound on result size in "return all" mode (there never was — the old 1000 default was dead code). A sane max could be added later as a safety valve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)